### PR TITLE
feat: Support processing full crash report instead of just crash lines

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,11 +3,11 @@
 const {argv} = require('yargs')
 const atos = require('./index')
 
-atos(argv, (error, symbols) => {
+atos(argv, (error, symbolicated) => {
   if (error != null) {
     console.error(error.stack || error.message)
     process.exit(1)
   } else {
-    console.log(symbols.join('\n'))
+    console.log(symbolicated.join('\n'))
   }
 })

--- a/spec/__snapshots__/symbolication.spec.js.snap
+++ b/spec/__snapshots__/symbolication.spec.js.snap
@@ -22,6 +22,17 @@ Array [
 ]
 `;
 
+exports[`atos returns content with addresses symbolicated 1`] = `
+Array [
+  "content::RenderProcessHostImpl::Cleanup() (in Electron Framework) (render_process_host_impl.cc:1908)",
+  "content::ServiceWorkerProcessManager::Shutdown() (in Electron Framework) (service_worker_process_manager.cc:79)",
+  "",
+  "Thread 1 Crashed:: Chrome_IOThread",
+  "worker (in libnode.dylib) (threadpool.c:76)",
+  "uv__thread_start (in libnode.dylib) (thread.c:54)",
+]
+`;
+
 exports[`atos returns an array of symbols for partially symbolicated addresses 1`] = `
 Array [
   "content::RenderProcessHostImpl::Cleanup() (in Electron Framework) (render_process_host_impl.cc:1908)",

--- a/spec/symbolication.spec.js
+++ b/spec/symbolication.spec.js
@@ -34,6 +34,15 @@ const post4Addresses = `
 47  libdyld.dylib                 	0x00007fff7a6513d5 start + 1
 `.trim()
 
+const fullReportFixture = `
+0   com.github.electron.framework 	0x000000010d01fad3 0x10c497000 + 12094163
+1   com.github.electron.framework 	0x000000010d095014 0x10c497000 + 12574740
+
+Thread 1 Crashed:: Chrome_IOThread
+3   libnode.dylib                 	0x000000010ab5c383 0x10aa09000 + 1389443
+4   libnode.dylib                 	0x000000010ab678e9 0x10aa09000 + 1435881
+`.trim()
+
 const TIMEOUT = 120000;
 
 describe('atos', function () {
@@ -64,6 +73,18 @@ describe('atos', function () {
   it('returns an array of symbols for partially symbolicated addresses', (done) => {
     atos({
       content: mixedFixture,
+      quiet: true,
+      version: '1.4.14'
+    }, (error, symbols) => {
+      if (error != null) return done(error)
+      expect(symbols).toMatchSnapshot()
+      done()
+    })
+  }, TIMEOUT)
+
+  it('returns content with addresses symbolicated', (done) => {
+    atos({
+      content: fullReportFixture,
       quiet: true,
       version: '1.4.14'
     }, (error, symbols) => {


### PR DESCRIPTION
This change generates a symbolicated report by symbolicating all the addresses in the original report. Until now, only symbolicating crash lines was supported. This makes it easier to have a final symbolicated report