### PR TITLE
fix: add shebang

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const path = require('path')
 const fs = require('fs')
 const breakpad = require('parse-breakpad')


### PR DESCRIPTION
I wasn't able to actually use `npx @electron/symbolicate-mac` bc the file isn't marked with a shebang. This PR adds the shebang to remedy this.