### PR TITLE
build(deps): update xcode version to `12.4.0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,12 @@ version: 2
 jobs:
   test-mac:
     macos:
-      xcode: "10.2.0"
+      xcode: "12.4.0"
     <<: *steps-test
 
   release:
     macos:
-      xcode: "10.2.0"
+      xcode: "12.4.0"
     steps:
       - checkout
       - *step-restore-cache


### PR DESCRIPTION
Our continuous integration pipeline wasn't running at all because the xcode
version specified was no longer supported.

```
Build-agent version 1.0.86821-ed7ce805 (2021-10-01T08:52:13+0000)
Creating a dedicated VM with xcode:10.2.0 image
failed to create host: Image xcode:10.2.0 is not supported

failed to create host: Image xcode:10.2.0 is not supported
```

This commit aligns the version with the one in `electron/electron`.

See: https://circleci.com/docs/2.0/xcode-policy/