### PR TITLE
test: update snapshot

### DIFF
--- a/spec/__snapshots__/symbolication.spec.js.snap
+++ b/spec/__snapshots__/symbolication.spec.js.snap
@@ -1610,7 +1610,7 @@ Note:             1 idle work queue thread omitted
                                           1000  CFRunLoopRunSpecific + 462 (CoreFoundation + 534814) [0x7fff3957691e]
                                             997  __CFRunLoopRun + 1319 (CoreFoundation + 537762) [0x7fff395774a2]
                                               997  __CFRunLoopServiceMachPort + 247 (CoreFoundation + 543189) [0x7fff395789d5]
-                                                997  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+                                                997  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
                                                  *997  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
                                             3    __CFRunLoopRun + 927 (CoreFoundation + 537370) [0x7fff3957731a]
                                               3    __CFRunLoopDoSources0 + 209 (CoreFoundation + 542187) [0x7fff395785eb]
@@ -1662,7 +1662,7 @@ Note:             1 idle work queue thread omitted
                                                                                                                           1    node::os::GetHostname(v8::FunctionCallbackInfo<v8::Value> const&) (Electron Framework + 55449694) [0x1118be85e]
                                                                                                                             1    uv_os_gethostname (Electron Framework + 47904) [0x10e3e8b20]
                                                                                                                               1    gethostname (libsystem_c.dylib + 160104) [0x7fff7368f168]
-                                                                                                                                1    __sysctl (libsystem_kernel.dylib + 8514) [0x7fff7375b142]
+                                                                                                                                1    __sysctl + 10 (libsystem_kernel.dylib + 8514) [0x7fff7375b142]
                                                                                                                                  *1    hndl_unix_scall64 + 22 (kernel + 778758) [0xffffff80002be206]
                                                                                                                                    *1    unix_syscall64 + 647 (kernel + 7870887) [0xffffff80009819a7]
                                                                                                                                      *1    sysctl + 705 (kernel + 6855025) [0xffffff8000889971]
@@ -1686,7 +1686,7 @@ Note:             1 idle work queue thread omitted
             1000  base::Thread::Run(base::RunLoop*) (Electron Framework + 26925656) [0x10fd8aa58]
               1000  base::RunLoop::Run(base::Location const&) (Electron Framework + 26621596) [0x10fd4069c]
                 1000  base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) (Electron Framework + 26808383) [0x10fd6e03f]
-                  1000  kevent64 (libsystem_kernel.dylib + 39830) [0x7fff73762b96]
+                  1000  kevent64 + 10 (libsystem_kernel.dylib + 39830) [0x7fff73762b96]
                    *1000  ??? (kernel + 6632800) [0xffffff8000853560]
 
   Thread 0x3442    Thread name "ThreadPoolBackgroundWorker"    1000 samples (1-1000)    priority 0 (base 0)
@@ -1697,7 +1697,7 @@ Note:             1 idle work queue thread omitted
           1000  base::internal::WorkerThread::RunWorker() (Electron Framework + 26892103) [0x10fd82747]
             1000  base::internal::WorkerThread::Delegate::WaitForWork(base::WaitableEvent*) (Electron Framework + 26890030) [0x10fd81f2e]
               1000  base::WaitableEvent::TimedWait(base::TimeDelta const&) (Electron Framework + 27048263) [0x10fda8947]
-                1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+                1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
                  *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x3444    Thread name "Chrome_IOThread"    1000 samples (1-1000)    priority 31 (base 31)    cpu time 0.007s (22.5M cycles, 7.3M instructions, 3.10c/i)
@@ -1709,17 +1709,17 @@ Note:             1 idle work queue thread omitted
             1000  base::Thread::Run(base::RunLoop*) (Electron Framework + 26925656) [0x10fd8aa58]
               1000  base::RunLoop::Run(base::Location const&) (Electron Framework + 26621596) [0x10fd4069c]
                 1000  base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) (Electron Framework + 26808383) [0x10fd6e03f]
-                  1000  kevent64 (libsystem_kernel.dylib + 39830) [0x7fff73762b96]
+                  1000  kevent64 + 10 (libsystem_kernel.dylib + 39830) [0x7fff73762b96]
                    *1000  ??? (kernel + 6632800) [0xffffff8000853560]
 
   Thread 0x3445    Thread name "MemoryInfra"    1000 samples (1-1000)    priority 31 (base 31)
   1000  <truncated backtrace>
-    1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+    1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
      *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x3448    1000 samples (1-1000)    priority 31 (base 31)
   1000  <truncated backtrace>
-    1000  kevent (libsystem_kernel.dylib + 22374) [0x7fff7375e766]
+    1000  kevent + 10 (libsystem_kernel.dylib + 22374) [0x7fff7375e766]
      *1000  ??? (kernel + 6632800) [0xffffff8000853560]
 
   Thread 0x3449    1000 samples (1-1000)    priority 31 (base 31)
@@ -1728,7 +1728,7 @@ Note:             1 idle work queue thread omitted
       1000  node::(anonymous namespace)::PlatformWorkerThread(void*) (Electron Framework + 55482023) [0x1118c66a7]
         1000  node::TaskQueue<v8::Task>::BlockingPop() (Electron Framework + 55492242) [0x1118c8e92]
           1000  uv_cond_wait (Electron Framework + 91657) [0x10e3f3609]
-            1000  __psynch_cvwait (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
+            1000  __psynch_cvwait + 10 (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
              *1000  psynch_cvcontinue + 0 (pthread + 18722) [0xffffff7f819bd922]
 
   Thread 0x344a    1000 samples (1-1000)    priority 31 (base 31)
@@ -1737,7 +1737,7 @@ Note:             1 idle work queue thread omitted
       1000  node::(anonymous namespace)::PlatformWorkerThread(void*) (Electron Framework + 55482023) [0x1118c66a7]
         1000  node::TaskQueue<v8::Task>::BlockingPop() (Electron Framework + 55492242) [0x1118c8e92]
           1000  uv_cond_wait (Electron Framework + 91657) [0x10e3f3609]
-            1000  __psynch_cvwait (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
+            1000  __psynch_cvwait + 10 (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
              *1000  psynch_cvcontinue + 0 (pthread + 18722) [0xffffff7f819bd922]
 
   Thread 0x344b    1000 samples (1-1000)    priority 31 (base 31)
@@ -1746,12 +1746,12 @@ Note:             1 idle work queue thread omitted
       1000  node::(anonymous namespace)::PlatformWorkerThread(void*) (Electron Framework + 55482023) [0x1118c66a7]
         1000  node::TaskQueue<v8::Task>::BlockingPop() (Electron Framework + 55492242) [0x1118c8e92]
           1000  uv_cond_wait (Electron Framework + 91657) [0x10e3f3609]
-            1000  __psynch_cvwait (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
+            1000  __psynch_cvwait + 10 (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
              *1000  psynch_cvcontinue + 0 (pthread + 18722) [0xffffff7f819bd922]
 
   Thread 0x3453    1000 samples (1-1000)    priority 31 (base 31)
   1000  <truncated backtrace>
-    1000  semaphore_wait_trap (libsystem_kernel.dylib + 3638) [0x7fff73759e36]
+    1000  semaphore_wait_trap + 10 (libsystem_kernel.dylib + 3638) [0x7fff73759e36]
      *1000  semaphore_wait_continue + 0 (kernel + 1325840) [0xffffff8000343b10]
 
   Thread 0x345d    1000 samples (1-1000)    priority 31 (base 31)    cpu time <0.001s (959.3K cycles, 485.5K instructions, 1.98c/i)
@@ -1759,7 +1759,7 @@ Note:             1 idle work queue thread omitted
     1000  _pthread_start (libsystem_pthread.dylib + 24841) [0x7fff7381d109]
       1000  worker (Electron Framework + 26761) [0x10e3e3889]
         1000  uv_cond_wait (Electron Framework + 91657) [0x10e3f3609]
-          1000  __psynch_cvwait (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
+          1000  __psynch_cvwait + 10 (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
            *1000  psynch_cvcontinue + 0 (pthread + 18722) [0xffffff7f819bd922]
 
   Thread 0x345e    1000 samples (1-1000)    priority 31 (base 31)    cpu time <0.001s (1274.6K cycles, 535.3K instructions, 2.38c/i)
@@ -1767,7 +1767,7 @@ Note:             1 idle work queue thread omitted
     1000  _pthread_start (libsystem_pthread.dylib + 24841) [0x7fff7381d109]
       1000  worker (Electron Framework + 26761) [0x10e3e3889]
         1000  uv_cond_wait (Electron Framework + 91657) [0x10e3f3609]
-          1000  __psynch_cvwait (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
+          1000  __psynch_cvwait + 10 (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
            *1000  psynch_cvcontinue + 0 (pthread + 18722) [0xffffff7f819bd922]
 
   Thread 0x345f    1000 samples (1-1000)    priority 31 (base 31)    cpu time <0.001s (992.4K cycles, 486.8K instructions, 2.04c/i)
@@ -1775,7 +1775,7 @@ Note:             1 idle work queue thread omitted
     1000  _pthread_start (libsystem_pthread.dylib + 24841) [0x7fff7381d109]
       1000  worker (Electron Framework + 26761) [0x10e3e3889]
         1000  uv_cond_wait (Electron Framework + 91657) [0x10e3f3609]
-          1000  __psynch_cvwait (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
+          1000  __psynch_cvwait + 10 (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
            *1000  psynch_cvcontinue + 0 (pthread + 18722) [0xffffff7f819bd922]
 
   Thread 0x3460    1000 samples (1-1000)    priority 31 (base 31)    cpu time <0.001s (1005.3K cycles, 527.0K instructions, 1.91c/i)
@@ -1783,27 +1783,27 @@ Note:             1 idle work queue thread omitted
     1000  _pthread_start (libsystem_pthread.dylib + 24841) [0x7fff7381d109]
       1000  worker (Electron Framework + 26761) [0x10e3e3889]
         1000  uv_cond_wait (Electron Framework + 91657) [0x10e3f3609]
-          1000  __psynch_cvwait (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
+          1000  __psynch_cvwait + 10 (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
            *1000  psynch_cvcontinue + 0 (pthread + 18722) [0xffffff7f819bd922]
 
   Thread 0x3484    1000 samples (1-1000)    priority 31 (base 31)
   1000  <truncated backtrace>
-    1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+    1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
      *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x3491    1000 samples (1-1000)    priority 31 (base 31)
   1000  <truncated backtrace>
-    1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+    1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
      *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x3494    Thread name "NetworkConfigWatcher"    1000 samples (1-1000)    priority 31 (base 31)
   1000  <truncated backtrace>
-    1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+    1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
      *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x3495    Thread name "CrShutdownDetector"    1000 samples (1-1000)    priority 31 (base 31)
   1000  <truncated backtrace>
-    1000  read (libsystem_kernel.dylib + 6174) [0x7fff7375a81e]
+    1000  read + 10 (libsystem_kernel.dylib + 6174) [0x7fff7375a81e]
      *1000  hndl_unix_scall64 + 22 (kernel + 778758) [0xffffff80002be206]
        *1000  unix_syscall64 + 647 (kernel + 7870887) [0xffffff80009819a7]
          *1000  read_nocancel + 138 (kernel + 6936426) [0xffffff800089d76a]
@@ -1817,7 +1817,7 @@ Note:             1 idle work queue thread omitted
 
   Thread 0x3496    Thread name "NetworkConfigWatcher"    1000 samples (1-1000)    priority 31 (base 31)
   1000  <truncated backtrace>
-    1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+    1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
      *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x3498    Thread name "CompositorTileWorker1"    1000 samples (1-1000)    priority 31 (base 31)
@@ -1826,7 +1826,7 @@ Note:             1 idle work queue thread omitted
       1000  base::(anonymous namespace)::ThreadFunc(void*) (Electron Framework + 27011432) [0x10fd9f968]
         1000  non-virtual thunk to cc::SingleThreadTaskGraphRunner::Run() (Electron Framework + 37009237) [0x110728755]
           1000  base::ConditionVariable::Wait() (Electron Framework + 27008848) [0x10fd9ef50]
-            1000  __psynch_cvwait (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
+            1000  __psynch_cvwait + 10 (libsystem_kernel.dylib + 14466) [0x7fff7375c882]
              *1000  psynch_cvcontinue + 0 (pthread + 18722) [0xffffff7f819bd922]
 
   Thread 0x3499    Thread name "ThreadPoolSingleThreadForegroundBlocking0"    1000 samples (1-1000)    priority 31 (base 31)
@@ -1838,22 +1838,22 @@ Note:             1 idle work queue thread omitted
             1000  base::internal::WorkerThread::Delegate::WaitForWork(base::WaitableEvent*) (Electron Framework + 26890045) [0x10fd81f3d]
               1000  base::WaitableEvent::Wait() (Electron Framework + 27047886) [0x10fda87ce]
                 1000  base::WaitableEvent::TimedWait(base::TimeDelta const&) (Electron Framework + 27048263) [0x10fda8947]
-                  1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+                  1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
                    *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x349b    1000 samples (1-1000)    priority 31 (base 31)    cpu time 0.002s (5.6M cycles, 2.2M instructions, 2.56c/i)
   1000  thread_start (libsystem_pthread.dylib + 7051) [0x7fff73818b8b]
     1000  _pthread_start (libsystem_pthread.dylib + 24841) [0x7fff7381d109]
       998  electron::NodeBindings::EmbedThreadRunner(void*) (Electron Framework + 1443048) [0x10e53d4e8]
-        998  __select (libsystem_kernel.dylib + 37118) [0x7fff737620fe]
+        998  __select + 10 (libsystem_kernel.dylib + 37118) [0x7fff737620fe]
          *998  ??? (kernel + 6832528) [0xffffff8000884190]
       2    electron::NodeBindings::EmbedThreadRunner(void*) (Electron Framework + 1443033) [0x10e53d4d9]
-        2    semaphore_wait_trap (libsystem_kernel.dylib + 3638) [0x7fff73759e36]
+        2    semaphore_wait_trap + 10 (libsystem_kernel.dylib + 3638) [0x7fff73759e36]
          *2    semaphore_wait_continue + 0 (kernel + 1325840) [0xffffff8000343b10]
 
   Thread 0x34c4    Thread name "NetworkConfigWatcher"    1000 samples (1-1000)    priority 31 (base 31)
   1000  <truncated backtrace>
-    1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+    1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
      *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x3500    Thread name "com.apple.NSEventThread"    1000 samples (1-1000)    priority 46 (base 46)
@@ -1863,12 +1863,12 @@ Note:             1 idle work queue thread omitted
         1000  CFRunLoopRunSpecific + 462 (CoreFoundation + 534814) [0x7fff3957691e]
           1000  __CFRunLoopRun + 1319 (CoreFoundation + 537762) [0x7fff395774a2]
             1000  __CFRunLoopServiceMachPort + 247 (CoreFoundation + 543189) [0x7fff395789d5]
-              1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+              1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
                *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x3512    Thread name "ThreadPoolSingleThreadSharedForegroundBlocking1"    1000 samples (1-1000)    priority 31 (base 31)
   1000  <truncated backtrace>
-    1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+    1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
      *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x3513    Thread name "CacheThread_BlockFile"    1000 samples (1-1000)    priority 31 (base 31)    cpu time <0.001s (242.9K cycles, 29.5K instructions, 8.24c/i)
@@ -1879,12 +1879,12 @@ Note:             1 idle work queue thread omitted
           1000  base::Thread::Run(base::RunLoop*) (Electron Framework + 26925656) [0x10fd8aa58]
             1000  base::RunLoop::Run(base::Location const&) (Electron Framework + 26621596) [0x10fd4069c]
               1000  base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) (Electron Framework + 26808383) [0x10fd6e03f]
-                1000  kevent64 (libsystem_kernel.dylib + 39830) [0x7fff73762b96]
+                1000  kevent64 + 10 (libsystem_kernel.dylib + 39830) [0x7fff73762b96]
                  *1000  ??? (kernel + 6632800) [0xffffff8000853560]
 
   Thread 0x3528    Thread name "ThreadPoolSingleThreadSharedBackgroundBlocking2"    1000 samples (1-1000)    priority 0 (base 0)
   1000  <truncated backtrace>
-    1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+    1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
      *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x11d18    Thread name "PowerSaveBlocker"    1000 samples (1-1000)    priority 31 (base 31)
@@ -1898,17 +1898,17 @@ Note:             1 idle work queue thread omitted
                 1000  base::MessagePumpDefault::Run(base::MessagePump::Delegate*) (Electron Framework + 26506375) [0x10fd24487]
                   1000  base::WaitableEvent::Wait() (Electron Framework + 27047886) [0x10fda87ce]
                     1000  base::WaitableEvent::TimedWait(base::TimeDelta const&) (Electron Framework + 27048263) [0x10fda8947]
-                      1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+                      1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
                        *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x37c8d    Thread name "AMCP Logging Spool"    1000 samples (1-1000)    priority 19 (base 19)
   1000  <truncated backtrace>
-    1000  semaphore_wait_trap (libsystem_kernel.dylib + 3638) [0x7fff73759e36]
+    1000  semaphore_wait_trap + 10 (libsystem_kernel.dylib + 3638) [0x7fff73759e36]
      *1000  semaphore_wait_continue + 0 (kernel + 1325840) [0xffffff8000343b10]
 
   Thread 0x37c8e    1000 samples (1-1000)    priority 55 (base 55)
   1000  <truncated backtrace>
-    1000  semaphore_wait_trap (libsystem_kernel.dylib + 3638) [0x7fff73759e36]
+    1000  semaphore_wait_trap + 10 (libsystem_kernel.dylib + 3638) [0x7fff73759e36]
      *1000  semaphore_wait_continue + 0 (kernel + 1325840) [0xffffff8000343b10]
 
   Thread 0x42fc34    Thread name "ThreadPoolForegroundWorker"    1000 samples (1-1000)    priority 31 (base 31)    cpu time <0.001s (1546.0K cycles, 831.7K instructions, 1.86c/i)
@@ -1919,7 +1919,7 @@ Note:             1 idle work queue thread omitted
           1000  base::internal::WorkerThread::RunWorker() (Electron Framework + 26892103) [0x10fd82747]
             1000  base::internal::WorkerThread::Delegate::WaitForWork(base::WaitableEvent*) (Electron Framework + 26890030) [0x10fd81f2e]
               1000  base::WaitableEvent::TimedWait(base::TimeDelta const&) (Electron Framework + 27048263) [0x10fda8947]
-                1000  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+                1000  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
                  *1000  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Thread 0x430f5e    Thread name "ThreadPoolForegroundWorker"    778 samples (223-1000)    priority 31-46 (base 31)    cpu time 0.002s (6.7M cycles, 5.7M instructions, 1.16c/i)
@@ -1930,7 +1930,7 @@ Note:             1 idle work queue thread omitted
           774  base::internal::WorkerThread::RunWorker() (Electron Framework + 26892103) [0x10fd82747]
             774  base::internal::WorkerThread::Delegate::WaitForWork(base::WaitableEvent*) (Electron Framework + 26890030) [0x10fd81f2e]
               774  base::WaitableEvent::TimedWait(base::TimeDelta const&) (Electron Framework + 27048263) [0x10fda8947]
-                774  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+                774  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
                  *774  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
           4    base::internal::WorkerThread::RunWorker() (Electron Framework + 26891876) [0x10fd82664]
             4    base::internal::TaskTracker::RunAndPopNextTask(base::internal::RegisteredTaskSource) (Electron Framework + 26852547) [0x10fd78cc3]
@@ -1943,7 +1943,7 @@ Note:             1 idle work queue thread omitted
                           2    leveldb::VersionSet::LogAndApply(leveldb::VersionEdit*, leveldb::port::Mutex*) (Electron Framework + 36063826) [0x110641a52]
                             1    leveldb_env::(anonymous namespace)::ChromiumWritableFile::Sync() (Electron Framework + 35996052) [0x110631194]
                               1    base::File::Flush() (Electron Framework + 26995661) [0x10fd9bbcd]
-                                1    __fcntl (libsystem_kernel.dylib + 6126) [0x7fff7375a7ee]
+                                1    __fcntl + 10 (libsystem_kernel.dylib + 6126) [0x7fff7375a7ee]
                                  *1    hndl_unix_scall64 + 22 (kernel + 778758) [0xffffff80002be206]
                                    *1    unix_syscall64 + 647 (kernel + 7870887) [0xffffff80009819a7]
                                      *1    fcntl_nocancel + 8739 (kernel + 6569891) [0xffffff8000843fa3]
@@ -1957,7 +1957,7 @@ Note:             1 idle work queue thread omitted
                                                      *1    machine_switch_context + 200 (kernel + 2353320) [0xffffff800043e8a8]
                             1    leveldb_env::(anonymous namespace)::ChromiumWritableFile::Sync() (Electron Framework + 35995833) [0x1106310b9]
                               1    base::File::Flush() (Electron Framework + 26995661) [0x10fd9bbcd]
-                                1    __fcntl (libsystem_kernel.dylib + 6126) [0x7fff7375a7ee]
+                                1    __fcntl + 10 (libsystem_kernel.dylib + 6126) [0x7fff7375a7ee]
                                  *1    hndl_unix_scall64 + 22 (kernel + 778758) [0xffffff80002be206]
                                    *1    unix_syscall64 + 647 (kernel + 7870887) [0xffffff80009819a7]
                                      *1    fcntl_nocancel + 8739 (kernel + 6569891) [0xffffff8000843fa3]
@@ -1974,7 +1974,7 @@ Note:             1 idle work queue thread omitted
                             1    leveldb_env::ChromiumEnv::RemoveFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) (Electron Framework + 35981759) [0x11062d9bf]
                               1    storage::FilesystemProxy::DeleteFile(base::FilePath const&) (Electron Framework + 36118719) [0x11064f0bf]
                                 1    base::(anonymous namespace)::DoDeleteFile(base::FilePath const&, bool) (Electron Framework + 26996633) [0x10fd9bf99]
-                                  1    __unlink (libsystem_kernel.dylib + 16098) [0x7fff7375cee2]
+                                  1    __unlink + 10 (libsystem_kernel.dylib + 16098) [0x7fff7375cee2]
                                    *1    hndl_unix_scall64 + 22 (kernel + 778758) [0xffffff80002be206]
                                      *1    unix_syscall64 + 647 (kernel + 7870887) [0xffffff80009819a7]
                                        *1    ??? (kernel + 3706734) [0xffffff8000588f6e]
@@ -2000,7 +2000,7 @@ Note:             1 idle work queue thread omitted
                             1    leveldb::BuildTable(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, leveldb::Env*, leveldb::Options const&, leveldb::TableCache*, leveldb::Iterator*, leveldb::FileMetaData*) (Electron Framework + 36001443) [0x1106326a3]
                               1    leveldb_env::(anonymous namespace)::ChromiumWritableFile::Sync() (Electron Framework + 35995833) [0x1106310b9]
                                 1    base::File::Flush() (Electron Framework + 26995661) [0x10fd9bbcd]
-                                  1    __fcntl (libsystem_kernel.dylib + 6126) [0x7fff7375a7ee]
+                                  1    __fcntl + 10 (libsystem_kernel.dylib + 6126) [0x7fff7375a7ee]
                                    *1    hndl_unix_scall64 + 22 (kernel + 778758) [0xffffff80002be206]
                                      *1    unix_syscall64 + 647 (kernel + 7870887) [0xffffff80009819a7]
                                        *1    fcntl_nocancel + 8739 (kernel + 6569891) [0xffffff8000843fa3]
@@ -2021,7 +2021,7 @@ Note:             1 idle work queue thread omitted
           778  base::internal::WorkerThread::RunWorker() (Electron Framework + 26891617) [0x10fd82561]
             778  base::internal::WorkerThread::Delegate::WaitForWork(base::WaitableEvent*) (Electron Framework + 26890030) [0x10fd81f2e]
               778  base::WaitableEvent::TimedWait(base::TimeDelta const&) (Electron Framework + 27048263) [0x10fda8947]
-                778  mach_msg_trap (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
+                778  mach_msg_trap + 10 (libsystem_kernel.dylib + 3578) [0x7fff73759dfa]
                  *778  ipc_mqueue_receive_continue + 0 (kernel + 1020080) [0xffffff80002f90b0]
 
   Binary Images:


### PR DESCRIPTION
I'm not sure which version of macOS caused this change, but the last successful run of CI was Feb 28 and by May 3 it was failing, so some macOS update from CircleCI between that time is when these snapshots became out-of-date.