### PR TITLE
test: fix broken snapshot

### DIFF
--- a/spec/__snapshots__/symbolication.spec.js.snap
+++ b/spec/__snapshots__/symbolication.spec.js.snap
@@ -1587,7 +1587,7 @@ CPU Time:         0.036s (117.7M cycles, 60.6M instructions, 1.94c/i)
 Note:             1 idle work queue thread omitted
 
   Thread 0x3316    DispatchQueue "com.apple.main-thread"(1)    Thread name "CrBrowserMain"    1000 samples (1-1000)    priority 46 (base 46)    cpu time 0.023s (76.7M cycles, 42.4M instructions, 1.81c/i)
-  1000  start + 1 (libdyld.dylib + 109769) [0x7fff73618cc9]
+  1000  start (libdyld.dylib + 109769) [0x7fff73618cc9]
     1000  ??? (Slack + 6118) [0x10e3817e6]
       1000  ElectronMain (Electron Framework + 114470) [0x10e3f8f26]
         1000  content::ContentMain(content::ContentMainParams const&) (Electron Framework + 7609010) [0x10eb1eab2]
@@ -1661,7 +1661,7 @@ Note:             1 idle work queue thread omitted
                                                                                                                         1    v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) (Electron Framework + 8427215) [0x10ebe66cf]
                                                                                                                           1    node::os::GetHostname(v8::FunctionCallbackInfo<v8::Value> const&) (Electron Framework + 55449694) [0x1118be85e]
                                                                                                                             1    uv_os_gethostname (Electron Framework + 47904) [0x10e3e8b20]
-                                                                                                                              1    gethostname + 179 (libsystem_c.dylib + 160104) [0x7fff7368f168]
+                                                                                                                              1    gethostname (libsystem_c.dylib + 160104) [0x7fff7368f168]
                                                                                                                                 1    __sysctl + 10 (libsystem_kernel.dylib + 8514) [0x7fff7375b142]
                                                                                                                                  *1    hndl_unix_scall64 + 22 (kernel + 778758) [0xffffff80002be206]
                                                                                                                                    *1    unix_syscall64 + 647 (kernel + 7870887) [0xffffff80009819a7]

--- a/spec/fixtures/spindump.txt
+++ b/spec/fixtures/spindump.txt
@@ -121,7 +121,7 @@ Note:             1 idle work queue thread omitted
                                                                                                                         1    v8::internal::baseline::BytecodeOffsetIterator::UpdatePointers() + 8975 (Electron Framework + 8427215) [0x10ebe66cf]
                                                                                                                           1    node::OnFatalError(char const*, char const*) + 396590 (Electron Framework + 55449694) [0x1118be85e]
                                                                                                                             1    uv_os_gethostname + 96 (Electron Framework + 47904) [0x10e3e8b20]
-                                                                                                                              1    gethostname + 179 (libsystem_c.dylib + 160104) [0x7fff7368f168]
+                                                                                                                              1    gethostname (libsystem_c.dylib + 160104) [0x7fff7368f168]
                                                                                                                                 1    __sysctl + 10 (libsystem_kernel.dylib + 8514) [0x7fff7375b142]
                                                                                                                                  *1    hndl_unix_scall64 + 22 (kernel + 778758) [0xffffff80002be206]
                                                                                                                                    *1    unix_syscall64 + 647 (kernel + 7870887) [0xffffff80009819a7]


### PR DESCRIPTION
See https://github.com/electron/symbolicate-mac/pull/67 - looks like a recent update reverted this